### PR TITLE
fix: make id blank when the resource is not found

### DIFF
--- a/dmsnitch/resource_snitch.go
+++ b/dmsnitch/resource_snitch.go
@@ -3,6 +3,7 @@ package dmsnitch
 import (
 	"context"
 	"log"
+	"net/http"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -122,8 +123,12 @@ func resourceSnitchCreate(d *schema.ResourceData, m interface{}) error {
 func resourceSnitchRead(d *schema.ResourceData, m interface{}) error {
 	client := m.(Client)
 	ctx := context.Background()
-	snitch, _, err := client.Get(ctx, d.Id()) //nolint:bodyclose
+	snitch, resp, err := client.Get(ctx, d.Id()) //nolint:bodyclose
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
https://www.terraform.io/docs/plugins/provider.html#read

> If the resource is no longer present, calling SetId with an empty string will signal its removal.

## Problem to solve

When a snitch created by this provider is removed manually,
it is failed to read (terraform plan, apply etc) because the resource isn't found.

```
Error: API Error: 404 https://api.deadmanssnitch.com/v1/snitches/*** The requested resource was not found.
```

## How to solve

By calling SetId with an empty string, Terraform treats the resource as removed, and read is succeeded.